### PR TITLE
maxima/minima of a constant value array has no peaks

### DIFF
--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -26,7 +26,8 @@ for (funcname, comp) in ((:maxima, :<),
                 @inbounds while i <= w
                     peak = true
                     for j in max(i-w, 1):(i+w)
-                        if ($comp)(x[i], x[j])
+                        i === j && continue
+                        if ($comp)(x[i], x[j]) || x[i] === x[j]
                             peak &= false
                             break # No reason to continue checking if the rest of the elements qualify
                         end
@@ -47,7 +48,7 @@ for (funcname, comp) in ((:maxima, :<),
             @inbounds while i <= maxI
                 peak = true
                 for j in ww # For all elements within the window
-                    if ($comp)(x[i], x[i+j])
+                    if ($comp)(x[i], x[i-j]) || x[i] === x[i-j]
                         peak &= false
                         break # No reason to continue checking if the rest of the elements qualify
                     end
@@ -65,7 +66,8 @@ for (funcname, comp) in ((:maxima, :<),
                 @inbounds while i <= xlen
                     peak = true
                     for j in (i-w):min((i+w),xlen)
-                        if ($comp)(x[i], x[j])
+                        i === j && continue
+                        if i !== j && ($comp)(x[i], x[j]) || x[i] === x[j]
                             peak &= false
                             break # No reason to continue checking if the rest of the elements qualify
                         end

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -24,4 +24,7 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
 
     @test length(maxima(x1, 1000, true)) == 5
     @test length(minima(x1, 1000, true)) == 5
+
+    # issue #4
+    @test isempty(maxima(zeros(10)))
 end

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -33,7 +33,7 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         minprom = 1.5
         i, p = peakprom(sin.(1e-5:1e-5:9*pi), Maxima())
         mi, mp = peakprom(sin.(1e-5:1e-5:9*pi), Maxima(), 1, minprom)
-        @test all(>=(minprom), mp)
+        @test all(x -> x >= minprom, mp)
     end
 
     # issue #4

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -33,21 +33,14 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         minprom = 1.5
         i, p = peakprom(sin.(1e-5:1e-5:9*pi), Maxima())
         mi, mp = peakprom(sin.(1e-5:1e-5:9*pi), Maxima(), 1, minprom)
+        @test all(>=(minprom), mp)
+    end
 
-        @test begin
-            for j in 1:5 # number of peaks in i and p
-                if i ∈ mi
-                    if p[j] < minprom
-                        return false
-                    end
-                else
-                    if p[j] >= minprom
-                        return false
-                    end
-                end
-            end
-            return true
-        end
+    # issue #4
+    let i, p
+        i, p = peakprom(zeros(10), Maxima())
+        @test isempty(i)
+        @test isempty(p)
     end
 end
 


### PR DESCRIPTION
If `x[i] === x[j]`, then `x[i] < x[j] === false` or `x[i] > x[j] === false`, whichever the case may be.
Fixes #4.

Previously, we didn't check if the less-than comparison between 2
elements was false because they were equal, this erroneously added peaks
in every window due to the default of `peak = true`.

Added checks to avoid comparing an element with itself, and checks to
treat equality between different elements as not a peak.