### PR TITLE
Limit Travis triggers for branches to master and tagged versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ jobs:
   allow_failures:
   - julia: nightly
 
+branches:
+  only:
+    - master
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
+
 codecov: true
 
 # remove following lines pending merging of https://github.com/travis-ci/travis-build/pull/1571


### PR DESCRIPTION
This should prevent double builds for PRs (for local branches, shouldn't be a problem for PRs from forks).