### PR TITLE
Peakprom bugfixes and API changes/improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,9 @@ version = "0.2.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 Compat = "2.1, 3"
-UnsafeArrays = "1"
 julia = "1"
 
 [extras]

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -14,8 +14,8 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
 
 @testset "Peak prominence" begin
     @testset "Reciprocity" begin
-        pi, pp = peakprom(x1, Maxima())
-        ni, np = peakprom(-x1, Minima())
+        pi, pp = peakprom(x1)
+        ni, np = peakprom(Minima(), -x1)
 
         @test pi == ni
         @test pp == np
@@ -23,22 +23,52 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
 
 
     @testset "Prominence values" begin
-        i, p = peakprom(sin.(1e-5:1e-5:9*pi), Maxima())
+        i, p = peakprom(sin.(1e-5:1e-5:9*pi))
 
         @test p[[1,5]] ≈ [1., 1.] atol=1e-4
         @test p[[2,3,4]] ≈ [2., 2., 2.] atol=1e-4
+
+        @test last(peakprom([1,0,2,0,1])) == [2]
+        @test last(peakprom([1,0,2,0,1]; strictbounds=false)) == [1,2,1]
+
+        # Prominence should be the same regardless of window size
+        p1 = [0,0,3,1,2,0,4,0,0,5]
+        @test last(peakprom(p1)) == [3,1,4]
+        @test last(peakprom(p1, 2)) == [3,4]
+
+        # A peaks of the same height count as an intersection for reference intervals
+        p4 = [0,4,2,4,3,4,0]
+        @test last(peakprom(p4)) == [2,1,1]
+        @test last(peakprom(p4[2:end-1])) == [1]
+        @test last(peakprom(p4[2:end-1]; strictbounds=false)) == [2,1,1]
+
+        # The presence of a missing/NaN in either bounding interval poisons the prominence
+        m4 = [missing; p4; missing]
+        n4 = [NaN; p4; NaN]
+        @test prod(last(peakprom(m4)) .=== [missing,1,missing])
+        @test prod(last(peakprom(n4)) .=== [NaN,1.,NaN])
+        @test last(peakprom(m4; strictbounds=false)) == [2,1,1]
+        @test last(peakprom(n4; strictbounds=false)) ≈ [2.,1.,1.] atol=0.01
+
+        @test_skip peakprom([missing,1,missing]; strictbounds=false) == [missing]
+
+        p5 = [-1,6,3,4,2,4,2,5,-2,0]
+        @test last(peakprom(p5, 3; strictbounds=false)) == [7,3]
+        @test last(peakprom(reverse(p5), 3; strictbounds=false)) == [3,7]
+
+
     end
 
     @testset "Minimum prominence" begin
         minprom = 1.5
-        i, p = peakprom(sin.(1e-5:1e-5:9*pi), Maxima())
-        mi, mp = peakprom(sin.(1e-5:1e-5:9*pi), Maxima(), 1, minprom)
+        i, p = peakprom(sin.(1e-5:1e-5:9*pi))
+        mi, mp = peakprom(sin.(1e-5:1e-5:9*pi); minprom)
         @test all(x -> x >= minprom, mp)
     end
 
     # issue #4
     let i, p
-        i, p = peakprom(zeros(10), Maxima())
+        i, p = peakprom(zeros(10))
         @test isempty(i)
         @test isempty(p)
     end

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -45,10 +45,10 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         # The presence of a missing/NaN in either bounding interval poisons the prominence
         m4 = [missing; p4; missing]
         n4 = [NaN; p4; NaN]
-        @test prod(last(peakprom(m4)) .=== [missing,1,missing])
-        @test prod(last(peakprom(n4)) .=== [NaN,1.,NaN])
+        @test isequal(last(peakprom(m4)), [missing,1,missing])
+        @test isequal(last(peakprom(n4)), [NaN,1.,NaN])
         @test last(peakprom(m4; strictbounds=false)) == [2,1,1]
-        @test last(peakprom(n4; strictbounds=false)) ≈ [2.,1.,1.] atol=0.01
+        @test last(peakprom(n4; strictbounds=false)) == [2.,1.,1.]
 
         @test_skip peakprom([missing,1,missing]; strictbounds=false) == [missing]
 


### PR DESCRIPTION
# API changes/new features:
- `strictbounds` is now a supported kwarg
- `minprom` is now a kwarg
- `peakprom` peak type argument (`Maxima()` or `Minima()`) is now the
first argument
- `Maxima()` is now the default for `peakprom`, allowing eg
`peakprom(x)` instead of `peakprom(Maxima(), x)`

# Bugfixes:
- `missing`/`NaN` support is now complete, correct, and fully
  tested
  - For `strictbounds = true`, a `missing`/`NaN` will be returned if either
  bounding interval contains `missing`/`NaN`.
  - For `strictbounds = false`, the most appropriate non-`missing`/`NaN` for
  each bounding interval will be used for the reference levels of each interval.

- Peaks of the same (identical) height now count for self-intersection
tests to determine bounding intervals. This will reduce returned peak
prominences in some (rare) cases, and is now different than MATLAB `findpeaks` behavior
(which this function's algorithm was originally based on). I think the new
behavior better matches the treatment of plateaus, and is more consistent with the
goal of calculating the "relative" prominence of peaks.

For an array `[0,4,2,4,3,4,0]`, imagine extending the center section to a
ridiculous length. Returning a prominence of 4 for every peak would not be an
accurate assessment of the relative prominence.

This PR:
```julia
julia> p4 = [0,4,2,4,3,4,0];

julia> peakprom(p4)
([2, 4, 6], [2, 1, 1])
```
Previous versions (and MATLAB):
```julia
julia> p4 = [0,4,2,4,3,4,0];

julia> peakprom(p4)
([2, 4, 6], [4, 4, 4])
```

Closes #9 