### PR TITLE
Rename min/maxima functions and deprecate old names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,9 @@ version = "0.2.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
 Compat = "2.1, 3"
-UnsafeArrays = "1"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Peaks.jl
 
+[![version](https://juliahub.com/docs/Peaks/version.svg)](https://juliahub.com/ui/Packages/Peaks/3TWUM)
 [![Build Status](https://travis-ci.com/halleysfifthinc/Peaks.jl.svg?branch=master)](https://travis-ci.com/halleysfifthinc/Peaks.jl)
+[![pkgeval](https://juliahub.com/docs/Peaks/pkgeval.svg)](https://juliahub.com/ui/Packages/Peaks/3TWUM)
 [![codecov](https://codecov.io/gh/halleysfifthinc/Peaks.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/halleysfifthinc/Peaks.jl)
 ![Maintenance](https://img.shields.io/maintenance/yes/2020)
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ Peaks.jl contains peak (local extrema) finding functions for vector data. Contri
 
 ## Functions
 
-- `maxima`/`minima`
+- `argmaxima`/`argminima`
   - Find the indices of the local extrema of `x` where each extrema is
     either the maximum of `x[-w:w]` or the first index of a plateau.
     If `strictbounds` is `true`, all elements of `x[-w:w]` must exist
     and may not be `missing` or `NaN`. If `strictbounds` is `false`,
     elements of `x[-w:w]` may not exist (eg peaks may be less than `w`
     indices from either end of `x`), or may be `missing` or `NaN`.
-    `missing` or `NaN` must not be extrema.
   - Supports OffsetArrays
   - See docstring for more information
+
+- `findmaxima`/`findminima` => (indices, values)
+  - Return the indices and values of local extrema
 
 - `peakprom`
   - Find all local extrema and peak prominences in `x` matching the
@@ -28,10 +30,9 @@ Peaks.jl contains peak (local extrema) finding functions for vector data. Contri
     returned extrema.
     Peak prominence is calculated as the difference between the current
     extrema and the most extreme of the smallest extrema of the lower and upper
-    bounds. Bounds extend from the current extrema to the next extrema
+    bounds. Bounds extend from the current extrema to the next element
     more extreme than the current extrema, or the end of the signal,
     which ever comes first.
-  - Does not currently support `strictbounds = false`
   - See docstring for more information
 
 ## Related

--- a/src/Peaks.jl
+++ b/src/Peaks.jl
@@ -2,6 +2,10 @@ module Peaks
 
 using Compat
 
+export argmaxima, argminima, findmaxima, findminima, peakprom
+
+export Maxima, Minima
+
 include("minmax.jl")
 include("peakprom.jl")
 

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -217,7 +217,7 @@ or `NaN` must not be maxima.
 """
 argmaxima
 
-function findmaxima(x, w; strictbounds=false)
+function findmaxima(x, w; strictbounds=true)
     idxs = argmaxima(x, w; strictbounds)
     return (idxs, x[idxs])
 end
@@ -235,7 +235,7 @@ or `NaN` must not be minima.
 """
 argminima
 
-function findminima(x, w; strictbounds=false)
+function findminima(x, w; strictbounds=true)
     idxs = argminima(x, w; strictbounds)
     return (idxs, x[idxs])
 end

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -1,5 +1,3 @@
-export argmaxima, argminima, maxima, minima
-
 for (funcname, comp, notcomp, val, TT) in ((:argmaxima, :<, :>, :i, Int),
     (:argminima, :>, :<, :i, Int))
     # FIXME: Enable maxima/minima => values after deprecation cycle

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -219,6 +219,11 @@ or `NaN` must not be maxima.
 """
 argmaxima
 
+function findmaxima(x, w; strictbounds=false)
+    idxs = argmaxima(x, w; strictbounds)
+    return (idxs, x[idxs])
+end
+
 @doc """
     argminima(x[, w=1; strictbounds=false])
 
@@ -231,6 +236,11 @@ be less than `w` indices from either end of `x`), or may be `missing` or `NaN`. 
 or `NaN` must not be minima.
 """
 argminima
+
+function findminima(x, w; strictbounds=false)
+    idxs = argminima(x, w; strictbounds)
+    return (idxs, x[idxs])
+end
 
 # Deprecations
 @deprecate maxima(x,w,strictbounds) argmaxima(x,w; strictbounds)

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -217,7 +217,7 @@ be less than `w` indices from either end of `x`), or may be `missing` or `NaN`.
 argmaxima
 
 function findmaxima(x, w::Integer=1; strictbounds::Bool=true)
-    idxs = argmaxima(x, w; strictbounds)
+    idxs = argmaxima(x, w; strictbounds=strictbounds)
     return (idxs, x[idxs])
 end
 
@@ -234,10 +234,10 @@ be less than `w` indices from either end of `x`), or may be `missing` or `NaN`.
 argminima
 
 function findminima(x, w::Integer=1; strictbounds::Bool=true)
-    idxs = argminima(x, w; strictbounds)
+    idxs = argminima(x, w; strictbounds=strictbounds)
     return (idxs, x[idxs])
 end
 
 # Deprecations
-@deprecate maxima(x,w=1,strictbounds=true) argmaxima(x,w; strictbounds)
-@deprecate minima(x,w=1,strictbounds=true) argminima(x,w; strictbounds)
+@deprecate maxima(x, w=1, strictbounds=true) argmaxima(x, w; strictbounds=strictbounds)
+@deprecate minima(x, w=1, strictbounds=true) argminima(x, w; strictbounds=strictbounds)

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -232,3 +232,6 @@ or `NaN` must not be minima.
 """
 argminima
 
+# Deprecations
+@deprecate maxima(x,w,strictbounds) argmaxima(x,w; strictbounds)
+@deprecate minima(x,w,strictbounds) argminima(x,w; strictbounds)

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -10,7 +10,7 @@ for (funcname, comp, notcomp, val, TT) in ((:argmaxima, :<, :>, :i, Int),
                         strictbounds::Bool=true) where T
             w > 0 || throw(ArgumentError("window cannot be negative"))
             xlen = length(x)
-            out = nonmissingtype($TT)[]
+            out = Base.nonmissingtype($TT)[]
 
             # There can't be more than one peak every `w` elements, but a peak is an element as well
             maxN = strictbounds ? max(0,fld(xlen-w,w+1)) : cld(xlen,w+1)

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -212,8 +212,7 @@ Find the indices of the local maxima of `x` where each maxima is either the maxi
 
 If `strictbounds` is `true`, all elements of `x[-w:w]` must exist and may not be `missing`
 or `NaN`. If `strictbounds` is `false`, elements of `x[-w:w]` may not exist (eg peaks may
-be less than `w` indices from either end of `x`), or may be `missing` or `NaN`. `missing`
-or `NaN` must not be maxima.
+be less than `w` indices from either end of `x`), or may be `missing` or `NaN`.
 """
 argmaxima
 
@@ -230,8 +229,7 @@ Find the indices of the local minima of `x` where each minima is either the mini
 
 If `strictbounds` is `true`, all elements of `x[-w:w]` must exist and may not be `missing`
 or `NaN`. If `strictbounds` is `false`, elements of `x[-w:w]` may not exist (eg peaks may
-be less than `w` indices from either end of `x`), or may be `missing` or `NaN`. `missing`
-or `NaN` must not be minima.
+be less than `w` indices from either end of `x`), or may be `missing` or `NaN`.
 """
 argminima
 

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -217,7 +217,7 @@ or `NaN` must not be maxima.
 """
 argmaxima
 
-function findmaxima(x, w; strictbounds=true)
+function findmaxima(x, w::Integer=1; strictbounds::Bool=true)
     idxs = argmaxima(x, w; strictbounds)
     return (idxs, x[idxs])
 end
@@ -235,11 +235,11 @@ or `NaN` must not be minima.
 """
 argminima
 
-function findminima(x, w; strictbounds=true)
+function findminima(x, w::Integer=1; strictbounds::Bool=true)
     idxs = argminima(x, w; strictbounds)
     return (idxs, x[idxs])
 end
 
 # Deprecations
-@deprecate maxima(x,w,strictbounds) argmaxima(x,w; strictbounds)
-@deprecate minima(x,w,strictbounds) argminima(x,w; strictbounds)
+@deprecate maxima(x,w=1,strictbounds=true) argmaxima(x,w; strictbounds)
+@deprecate minima(x,w=1,strictbounds=true) argminima(x,w; strictbounds)

--- a/src/minmax.jl
+++ b/src/minmax.jl
@@ -8,7 +8,7 @@ for (funcname, comp, notcomp, val, TT) in ((:argmaxima, :<, :>, :i, Int),
 
     @eval begin
         function ($funcname)(x::AbstractVector{T},
-                        w::Integer=1,
+                        w::Integer=1;
                         strictbounds::Bool=true) where T
             w > 0 || throw(ArgumentError("window cannot be negative"))
             xlen = length(x)
@@ -207,7 +207,7 @@ for (funcname, comp, notcomp, val, TT) in ((:argmaxima, :<, :>, :i, Int),
 end
 
 @doc """
-    argmaxima(x[, w=1, strictbounds=true])
+    argmaxima(x[, w=1; strictbounds=true])
 
 Find the indices of the local maxima of `x` where each maxima is either the maximum of
 `x[-w:w]` or the first index of a plateau.
@@ -220,7 +220,7 @@ or `NaN` must not be maxima.
 argmaxima
 
 @doc """
-    argminima(x[, w=1, strictbounds=false])
+    argminima(x[, w=1; strictbounds=false])
 
 Find the indices of the local minima of `x` where each minima is either the minimum of
 `x[-w:w]` or the first index of a plateau.

--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -1,10 +1,5 @@
 using UnsafeArrays
 
-export Maxima,
-       Minima
-
-export peakprom
-
 struct Maxima; end
 struct Minima; end
 

--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -16,9 +16,9 @@ for (comps, Extrema) in (((:>, minimum, max), Maxima),
     @eval begin
         function peakprom(x::AbstractVector{T}, ::$Extrema, w=1, minprom::T=zero(T)) where T
             if ($Extrema) === Maxima
-                m = maxima(x, w)
+                m = argmaxima(x, w)
             else
-                m = minima(x, w)
+                m = argminima(x, w)
             end
 
             M = lastindex(m)
@@ -66,7 +66,7 @@ end
 @doc """
     peakprom(x, ::Maxima[, w=1, minprom=0])
 
-Find all local maxima and maxima prominences in `x` matching the conditions `w` and `minprom`.
+Find the indices of all local maxima and their prominences in `x` matching the conditions `w` and `minprom`.
 `w` sets the minimum allowed distance between maxima. `minprom` sets the minimum prominence
 (inclusive) of returned maxima.
 
@@ -87,14 +87,14 @@ julia> @assert (mi == ma) && (pa == pi)
 
 ```
 
-See also: [`maxima`](@ref), [`minima`](@ref)
+See also: [`argmaxima`](@ref), [`maxima`](@ref)
 """
 peakprom(x, ::Maxima)
 
 @doc """
     peakprom(x, ::Minima[, w=1, minprom=0])
 
-Find all local minima and minima prominences in `x` matching the conditions `w` and `minprom`.
+Find the indices of all local minima and their prominences in `x` matching the conditions `w` and `minprom`.
 `w` sets the minimum allowed distance between minima. `minprom` sets the minimum prominence
 (inclusive) of returned minima.
 
@@ -103,7 +103,7 @@ the maximums of the lower and upper bounds. Bounds extend from the next index fr
 current minima to the next minima lower than the current minima, or the end of the signal,
 which ever comes first.
 
-See also: [`maxima`](@ref), [`minima`](@ref)
+See also: [`argminima`](@ref), [`minima`](@ref)
 """
 peakprom(x, ::Minima)
 

--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -12,7 +12,7 @@ for (comps, Extrema) in (((:>=, minimum, max), Maxima),
             strictbounds=true, minprom=nothing
         ) where T
             if ($Extrema) === Maxima
-                m = argmaxima(x, w; strictbounds)
+                m = argmaxima(x, w; strictbounds=strictbounds)
 
                 # The extremum search space in the bounding intervals can be reduced by
                 # restricting the search space to known peaks/reverse peaks. The cost of
@@ -24,7 +24,7 @@ for (comps, Extrema) in (((:>=, minimum, max), Maxima),
                     notm = argminima(x, 1; strictbounds=false)
                 end
             else
-                m = argminima(x, w; strictbounds)
+                m = argminima(x, w; strictbounds=strictbounds)
                 if !strictbounds
                     m′ = (w === 1) ? m : argminima(x, 1; strictbounds=false)
                     notm = argmaxima(x, 1; strictbounds=false)

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -12,130 +12,130 @@ t = T:T:fs
 
 x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
 
-@testset "Minima/maxima" begin
-    @test length(maxima(x1)) == 30
-    @test length(minima(x1)) == 30
+@testset "argminima/argmaxima" begin
+    @test length(argmaxima(x1)) == 30
+    @test length(argminima(x1)) == 30
 
-    @test length(maxima(x1, 1, false)) == 31
-    @test length(minima(x1, 1, false)) == 31
+    @test length(argmaxima(x1, 1, false)) == 31
+    @test length(argminima(x1, 1, false)) == 31
 
     # OffsetArrays
     x1_off = OffsetArray(x1, -200:length(x1)-201)
-    @test length(maxima(x1_off)) == 30
-    @test length(minima(x1_off)) == 30
-    @test maxima(x1_off) == maxima(x1) .- 201
-    @test minima(x1_off) == minima(x1) .- 201
-    @test length(maxima(x1_off, 1, false)) == 31
-    @test length(minima(x1_off, 1, false)) == 31
-    @test maxima(x1_off, 1, false) == maxima(x1, 1, false) .- 201
-    @test minima(x1_off, 1, false) == minima(x1, 1, false) .- 201
+    @test length(argmaxima(x1_off)) == 30
+    @test length(argminima(x1_off)) == 30
+    @test argmaxima(x1_off) == argmaxima(x1) .- 201
+    @test argminima(x1_off) == argminima(x1) .- 201
+    @test length(argmaxima(x1_off, 1, false)) == 31
+    @test length(argminima(x1_off, 1, false)) == 31
+    @test argmaxima(x1_off, 1, false) == argmaxima(x1, 1, false) .- 201
+    @test argminima(x1_off, 1, false) == argminima(x1, 1, false) .- 201
 
-    @test length(maxima(x1, 1000)) == 4
-    @test length(minima(x1, 1000)) == 4
+    @test length(argmaxima(x1, 1000)) == 4
+    @test length(argminima(x1, 1000)) == 4
 
-    @test length(maxima(x1, 1000, false)) == 5
-    @test length(minima(x1, 1000, false)) == 5
+    @test length(argmaxima(x1, 1000, false)) == 5
+    @test length(argminima(x1, 1000, false)) == 5
 
-    @test maxima([0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],2) == [4,8,12]
-    @test maxima([0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],2,false) == [2,6,10,14]
+    @test argmaxima([0,1,0,1,0,1,0,1,0,1,0,1,0,1,0], 2) == [4,8,12]
+    @test argmaxima([0,1,0,1,0,1,0,1,0,1,0,1,0,1,0], 2, false) == [2,6,10,14]
 
     @testset "Plateaus" begin
         p1 = [0,1,1,1,1,1]
         p2 = [0,0,1,1,1,1]
         p3 = [0,0,0,0,1,1]
 
-        @test maxima( p1, 2, false) == [2]
-        @test minima(-p1, 2, false) == [2]
-        @test maxima( p2, 2, false) == [3]
-        @test minima(-p2, 2, false) == [3]
-        @test maxima( p3, 2, false) == [5]
-        @test minima(-p3, 2, false) == [5]
+        @test argmaxima( p1, 2, false) == [2]
+        @test argminima(-p1, 2, false) == [2]
+        @test argmaxima( p2, 2, false) == [3]
+        @test argminima(-p2, 2, false) == [3]
+        @test argmaxima( p3, 2, false) == [5]
+        @test argminima(-p3, 2, false) == [5]
 
-        @test isempty(maxima( p1))
-        @test isempty(minima(-p1))
-        @test isempty(maxima( p2))
-        @test isempty(minima(-p2))
-        @test isempty(maxima( p3))
-        @test isempty(minima(-p3))
+        @test isempty(argmaxima( p1))
+        @test isempty(argminima(-p1))
+        @test isempty(argmaxima( p2))
+        @test isempty(argminima(-p2))
+        @test isempty(argmaxima( p3))
+        @test isempty(argminima(-p3))
 
-        @test maxima(reverse( p1), 2, false) == [1]
-        @test minima(reverse(-p1), 2, false) == [1]
-        @test maxima(reverse( p2), 2, false) == [1]
-        @test minima(reverse(-p2), 2, false) == [1]
-        @test maxima(reverse( p3), 2, false) == [1]
-        @test minima(reverse(-p3), 2, false) == [1]
+        @test argmaxima(reverse( p1), 2, false) == [1]
+        @test argminima(reverse(-p1), 2, false) == [1]
+        @test argmaxima(reverse( p2), 2, false) == [1]
+        @test argminima(reverse(-p2), 2, false) == [1]
+        @test argmaxima(reverse( p3), 2, false) == [1]
+        @test argminima(reverse(-p3), 2, false) == [1]
 
-        @test isempty(maxima(reverse( p1)))
-        @test isempty(minima(reverse(-p1)))
-        @test isempty(maxima(reverse( p2)))
-        @test isempty(minima(reverse(-p2)))
-        @test isempty(maxima(reverse( p3)))
-        @test isempty(minima(reverse(-p3)))
+        @test isempty(argmaxima(reverse( p1)))
+        @test isempty(argminima(reverse(-p1)))
+        @test isempty(argmaxima(reverse( p2)))
+        @test isempty(argminima(reverse(-p2)))
+        @test isempty(argmaxima(reverse( p3)))
+        @test isempty(argminima(reverse(-p3)))
 
-        @test maxima( [0,1,1,1,1,0]) == [2]
-        @test minima(-[0,1,1,1,1,0]) == [2]
-        @test maxima( [0,1,1,1,2,0]) == [5]
-        @test minima(-[0,1,1,1,2,0]) == [5]
-        @test maxima( [0,1,1,0,2,1], 3, false) == [5]
-        @test minima(-[0,1,1,0,2,1], 3, false) == [5]
+        @test argmaxima( [0,1,1,1,1,0]) == [2]
+        @test argminima(-[0,1,1,1,1,0]) == [2]
+        @test argmaxima( [0,1,1,1,2,0]) == [5]
+        @test argminima(-[0,1,1,1,2,0]) == [5]
+        @test argmaxima( [0,1,1,0,2,1], 3, false) == [5]
+        @test argminima(-[0,1,1,0,2,1], 3, false) == [5]
 
         # issue #4
-        @test isempty(maxima(zeros(10)))
-        @test maxima(zeros(10),1,false) == [1]
+        @test isempty(argmaxima(zeros(10)))
+        @test argmaxima(zeros(10), 1, false) == [1]
     end
 
     # A missing or NaN should not occur within the `w` of the peak
     @testset "Missings and NaNs" begin
         m1 = [0,0,1,1,1,missing,missing,0,0]
         n1 = [0,0,1,1,1,NaN,NaN,0,0]
-        @test isempty(maxima( m1, 1, true))
-        @test isempty(maxima( n1, 1, true))
-        @test isempty(minima(-m1, 1, true))
-        @test isempty(minima(-n1, 1, true))
-        @test maxima( m1, 1, false) == [3,8]
-        @test maxima( n1, 1, false) == [3,8]
-        @test minima(-m1, 1, false) == [3,8]
-        @test minima(-n1, 1, false) == [3,8]
+        @test isempty(argmaxima( m1, 1, true))
+        @test isempty(argmaxima( n1, 1, true))
+        @test isempty(argminima(-m1, 1, true))
+        @test isempty(argminima(-n1, 1, true))
+        @test argmaxima( m1, 1, false) == [3,8]
+        @test argmaxima( n1, 1, false) == [3,8]
+        @test argminima(-m1, 1, false) == [3,8]
+        @test argminima(-n1, 1, false) == [3,8]
 
-        @test isempty(maxima(reverse( m1), 1, true))
-        @test isempty(maxima(reverse( n1), 1, true))
-        @test isempty(minima(reverse(-m1), 1, true))
-        @test isempty(minima(reverse(-n1), 1, true))
-        @test maxima(reverse( m1), 1, false) == [1,5]
-        @test maxima(reverse( n1), 1, false) == [1,5]
-        @test minima(reverse(-m1), 1, false) == [1,5]
-        @test minima(reverse(-n1), 1, false) == [1,5]
+        @test isempty(argmaxima(reverse( m1), 1, true))
+        @test isempty(argmaxima(reverse( n1), 1, true))
+        @test isempty(argminima(reverse(-m1), 1, true))
+        @test isempty(argminima(reverse(-n1), 1, true))
+        @test argmaxima(reverse( m1), 1, false) == [1,5]
+        @test argmaxima(reverse( n1), 1, false) == [1,5]
+        @test argminima(reverse(-m1), 1, false) == [1,5]
+        @test argminima(reverse(-n1), 1, false) == [1,5]
 
         m2 = [0,1,2,1,missing,missing,missing]
         n2 = [0,1,2,1,NaN,NaN,NaN]
-        @test maxima(m2, 1) == [3]
-        @test maxima(n2, 1) == [3]
-        @test isempty(maxima(m2, 2))
-        @test isempty(maxima(n2, 2))
-        @test minima(-m2, 1) == [3]
-        @test minima(-n2, 1) == [3]
-        @test isempty(minima(-m2, 2))
-        @test isempty(minima(-n2, 2))
-        @test maxima(reverse(m2), 1) == [5]
-        @test maxima(reverse(n2), 1) == [5]
-        @test isempty(maxima(reverse(m2), 2))
-        @test isempty(maxima(reverse(n2), 2))
-        @test minima(reverse(-m2), 1) == [5]
-        @test minima(reverse(-n2), 1) == [5]
-        @test isempty(minima(reverse(-m2), 2))
-        @test isempty(minima(reverse(-n2), 2))
+        @test argmaxima(m2, 1) == [3]
+        @test argmaxima(n2, 1) == [3]
+        @test isempty(argmaxima(m2, 2))
+        @test isempty(argmaxima(n2, 2))
+        @test argminima(-m2, 1) == [3]
+        @test argminima(-n2, 1) == [3]
+        @test isempty(argminima(-m2, 2))
+        @test isempty(argminima(-n2, 2))
+        @test argmaxima(reverse(m2), 1) == [5]
+        @test argmaxima(reverse(n2), 1) == [5]
+        @test isempty(argmaxima(reverse(m2), 2))
+        @test isempty(argmaxima(reverse(n2), 2))
+        @test argminima(reverse(-m2), 1) == [5]
+        @test argminima(reverse(-n2), 1) == [5]
+        @test isempty(argminima(reverse(-m2), 2))
+        @test isempty(argminima(reverse(-n2), 2))
 
         m3 = [0,1,0,1,missing,1,0,1,0]
         n3 = [0,1,0,1,NaN,1,0,1,0]
-        @test maxima(m3) == [2,8]
-        @test minima(-m3) == [2,8]
-        @test maxima(n3) == [2,8]
-        @test minima(-n3) == [2,8]
+        @test argmaxima(m3) == [2,8]
+        @test argminima(-m3) == [2,8]
+        @test argmaxima(n3) == [2,8]
+        @test argminima(-n3) == [2,8]
 
         mn = [1,NaN,missing,1]
-        @test isempty(maxima(mn))
-        @test isempty(minima(mn))
-        @test isempty(maxima(reverse(mn)))
-        @test isempty(minima(reverse(mn)))
+        @test isempty(argmaxima(mn))
+        @test isempty(argminima(mn))
+        @test isempty(argmaxima(reverse(mn)))
+        @test isempty(argminima(reverse(mn)))
     end
 end

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -16,8 +16,8 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
     @test length(argmaxima(x1)) == 30
     @test length(argminima(x1)) == 30
 
-    @test length(argmaxima(x1, 1, false)) == 31
-    @test length(argminima(x1, 1, false)) == 31
+    @test length(argmaxima(x1, 1; strictbounds=false)) == 31
+    @test length(argminima(x1, 1; strictbounds=false)) == 31
 
     # OffsetArrays
     x1_off = OffsetArray(x1, -200:length(x1)-201)
@@ -25,31 +25,31 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
     @test length(argminima(x1_off)) == 30
     @test argmaxima(x1_off) == argmaxima(x1) .- 201
     @test argminima(x1_off) == argminima(x1) .- 201
-    @test length(argmaxima(x1_off, 1, false)) == 31
-    @test length(argminima(x1_off, 1, false)) == 31
-    @test argmaxima(x1_off, 1, false) == argmaxima(x1, 1, false) .- 201
-    @test argminima(x1_off, 1, false) == argminima(x1, 1, false) .- 201
+    @test length(argmaxima(x1_off, 1; strictbounds=false)) == 31
+    @test length(argminima(x1_off, 1; strictbounds=false)) == 31
+    @test argmaxima(x1_off, 1; strictbounds=false) == argmaxima(x1, 1; strictbounds=false) .- 201
+    @test argminima(x1_off, 1; strictbounds=false) == argminima(x1, 1; strictbounds=false) .- 201
 
     @test length(argmaxima(x1, 1000)) == 4
     @test length(argminima(x1, 1000)) == 4
 
-    @test length(argmaxima(x1, 1000, false)) == 5
-    @test length(argminima(x1, 1000, false)) == 5
+    @test length(argmaxima(x1, 1000; strictbounds=false)) == 5
+    @test length(argminima(x1, 1000; strictbounds=false)) == 5
 
     @test argmaxima([0,1,0,1,0,1,0,1,0,1,0,1,0,1,0], 2) == [4,8,12]
-    @test argmaxima([0,1,0,1,0,1,0,1,0,1,0,1,0,1,0], 2, false) == [2,6,10,14]
+    @test argmaxima([0,1,0,1,0,1,0,1,0,1,0,1,0,1,0], 2; strictbounds=false) == [2,6,10,14]
 
     @testset "Plateaus" begin
         p1 = [0,1,1,1,1,1]
         p2 = [0,0,1,1,1,1]
         p3 = [0,0,0,0,1,1]
 
-        @test argmaxima( p1, 2, false) == [2]
-        @test argminima(-p1, 2, false) == [2]
-        @test argmaxima( p2, 2, false) == [3]
-        @test argminima(-p2, 2, false) == [3]
-        @test argmaxima( p3, 2, false) == [5]
-        @test argminima(-p3, 2, false) == [5]
+        @test argmaxima( p1, 2; strictbounds=false) == [2]
+        @test argminima(-p1, 2; strictbounds=false) == [2]
+        @test argmaxima( p2, 2; strictbounds=false) == [3]
+        @test argminima(-p2, 2; strictbounds=false) == [3]
+        @test argmaxima( p3, 2; strictbounds=false) == [5]
+        @test argminima(-p3, 2; strictbounds=false) == [5]
 
         @test isempty(argmaxima( p1))
         @test isempty(argminima(-p1))
@@ -58,12 +58,12 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         @test isempty(argmaxima( p3))
         @test isempty(argminima(-p3))
 
-        @test argmaxima(reverse( p1), 2, false) == [1]
-        @test argminima(reverse(-p1), 2, false) == [1]
-        @test argmaxima(reverse( p2), 2, false) == [1]
-        @test argminima(reverse(-p2), 2, false) == [1]
-        @test argmaxima(reverse( p3), 2, false) == [1]
-        @test argminima(reverse(-p3), 2, false) == [1]
+        @test argmaxima(reverse( p1), 2; strictbounds=false) == [1]
+        @test argminima(reverse(-p1), 2; strictbounds=false) == [1]
+        @test argmaxima(reverse( p2), 2; strictbounds=false) == [1]
+        @test argminima(reverse(-p2), 2; strictbounds=false) == [1]
+        @test argmaxima(reverse( p3), 2; strictbounds=false) == [1]
+        @test argminima(reverse(-p3), 2; strictbounds=false) == [1]
 
         @test isempty(argmaxima(reverse( p1)))
         @test isempty(argminima(reverse(-p1)))
@@ -76,35 +76,35 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         @test argminima(-[0,1,1,1,1,0]) == [2]
         @test argmaxima( [0,1,1,1,2,0]) == [5]
         @test argminima(-[0,1,1,1,2,0]) == [5]
-        @test argmaxima( [0,1,1,0,2,1], 3, false) == [5]
-        @test argminima(-[0,1,1,0,2,1], 3, false) == [5]
+        @test argmaxima( [0,1,1,0,2,1], 3; strictbounds=false) == [5]
+        @test argminima(-[0,1,1,0,2,1], 3; strictbounds=false) == [5]
 
         # issue #4
         @test isempty(argmaxima(zeros(10)))
-        @test argmaxima(zeros(10), 1, false) == [1]
+        @test argmaxima(zeros(10), 1; strictbounds=false) == [1]
     end
 
     # A missing or NaN should not occur within the `w` of the peak
     @testset "Missings and NaNs" begin
         m1 = [0,0,1,1,1,missing,missing,0,0]
         n1 = [0,0,1,1,1,NaN,NaN,0,0]
-        @test isempty(argmaxima( m1, 1, true))
-        @test isempty(argmaxima( n1, 1, true))
-        @test isempty(argminima(-m1, 1, true))
-        @test isempty(argminima(-n1, 1, true))
-        @test argmaxima( m1, 1, false) == [3,8]
-        @test argmaxima( n1, 1, false) == [3,8]
-        @test argminima(-m1, 1, false) == [3,8]
-        @test argminima(-n1, 1, false) == [3,8]
+        @test isempty(argmaxima( m1, 1; strictbounds=true))
+        @test isempty(argmaxima( n1, 1; strictbounds=true))
+        @test isempty(argminima(-m1, 1; strictbounds=true))
+        @test isempty(argminima(-n1, 1; strictbounds=true))
+        @test argmaxima( m1, 1; strictbounds=false) == [3,8]
+        @test argmaxima( n1, 1; strictbounds=false) == [3,8]
+        @test argminima(-m1, 1; strictbounds=false) == [3,8]
+        @test argminima(-n1, 1; strictbounds=false) == [3,8]
 
-        @test isempty(argmaxima(reverse( m1), 1, true))
-        @test isempty(argmaxima(reverse( n1), 1, true))
-        @test isempty(argminima(reverse(-m1), 1, true))
-        @test isempty(argminima(reverse(-n1), 1, true))
-        @test argmaxima(reverse( m1), 1, false) == [1,5]
-        @test argmaxima(reverse( n1), 1, false) == [1,5]
-        @test argminima(reverse(-m1), 1, false) == [1,5]
-        @test argminima(reverse(-n1), 1, false) == [1,5]
+        @test isempty(argmaxima(reverse( m1), 1; strictbounds=true))
+        @test isempty(argmaxima(reverse( n1), 1; strictbounds=true))
+        @test isempty(argminima(reverse(-m1), 1; strictbounds=true))
+        @test isempty(argminima(reverse(-n1), 1; strictbounds=true))
+        @test argmaxima(reverse( m1), 1; strictbounds=false) == [1,5]
+        @test argmaxima(reverse( n1), 1; strictbounds=false) == [1,5]
+        @test argminima(reverse(-m1), 1; strictbounds=false) == [1,5]
+        @test argminima(reverse(-n1), 1; strictbounds=false) == [1,5]
 
         m2 = [0,1,2,1,missing,missing,missing]
         n2 = [0,1,2,1,NaN,NaN,NaN]

--- a/test/minmax.jl
+++ b/test/minmax.jl
@@ -138,4 +138,7 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         @test isempty(argmaxima(reverse(mn)))
         @test isempty(argminima(reverse(mn)))
     end
+
+    @test_deprecated maxima(x1, 1, false)
+    @test_deprecated minima(x1, 1, false)
 end

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -14,8 +14,8 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
 
 @testset "Peak prominence" begin
     @testset "Reciprocity" begin
-        pi, pp = peakprom(x1, Maxima())
-        ni, np = peakprom(-x1, Minima())
+        pi, pp = peakprom(x1)
+        ni, np = peakprom(Minima(), -x1)
 
         @test pi == ni
         @test pp == np
@@ -23,22 +23,52 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
 
 
     @testset "Prominence values" begin
-        i, p = peakprom(sin.(1e-5:1e-5:9*pi), Maxima())
+        i, p = peakprom(sin.(1e-5:1e-5:9*pi))
 
         @test p[[1,5]] ≈ [1., 1.] atol=1e-4
         @test p[[2,3,4]] ≈ [2., 2., 2.] atol=1e-4
+
+        @test last(peakprom([1,0,2,0,1])) == [2]
+        @test last(peakprom([1,0,2,0,1]; strictbounds=false)) == [1,2,1]
+
+        # Prominence should be the same regardless of window size
+        p1 = [0,0,3,1,2,0,4,0,0,5]
+        @test last(peakprom(p1)) == [3,1,4]
+        @test last(peakprom(p1, 2)) == [3,4]
+
+        # A peaks of the same height count as an intersection for reference intervals
+        p4 = [0,4,2,4,3,4,0]
+        @test last(peakprom(p4)) == [2,1,1]
+        @test last(peakprom(p4[2:end-1])) == [1]
+        @test last(peakprom(p4[2:end-1]; strictbounds=false)) == [2,1,1]
+
+        # The presence of a missing/NaN in either bounding interval poisons the prominence
+        m4 = [missing; p4; missing]
+        n4 = [NaN; p4; NaN]
+        @test prod(last(peakprom(m4)) .=== [missing,1,missing])
+        @test prod(last(peakprom(n4)) .=== [NaN,1.,NaN])
+        @test last(peakprom(m4; strictbounds=false)) == [2,1,1]
+        @test last(peakprom(n4; strictbounds=false)) ≈ [2.,1.,1.] atol=0.01
+
+        @test_skip peakprom([missing,1,missing]; strictbounds=false) == [missing]
+
+        p5 = [-1,6,3,4,2,4,2,5,-2,0]
+        @test last(peakprom(p5, 3; strictbounds=false)) == [7,3]
+        @test last(peakprom(reverse(p5), 3; strictbounds=false)) == [3,7]
+
+
     end
 
     @testset "Minimum prominence" begin
         minprom = 1.5
-        i, p = peakprom(sin.(1e-5:1e-5:9*pi), Maxima())
-        mi, mp = peakprom(sin.(1e-5:1e-5:9*pi), Maxima(), 1, minprom)
+        i, p = peakprom(sin.(1e-5:1e-5:9*pi))
+        mi, mp = peakprom(sin.(1e-5:1e-5:9*pi); minprom)
         @test all(x -> x >= minprom, mp)
     end
 
     # issue #4
     let i, p
-        i, p = peakprom(zeros(10), Maxima())
+        i, p = peakprom(zeros(10))
         @test isempty(i)
         @test isempty(p)
     end

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -50,7 +50,7 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         @test last(peakprom(m4; strictbounds=false)) == [2,1,1]
         @test last(peakprom(n4; strictbounds=false)) == [2.,1.,1.]
 
-        @test_skip peakprom([missing,1,missing]; strictbounds=false) == [missing]
+        @test last(peakprom([missing,1,missing]; strictbounds=false)) == [0]
 
         p5 = [-1,6,3,4,2,4,2,5,-2,0]
         @test last(peakprom(p5, 3; strictbounds=false)) == [7,3]

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -45,10 +45,10 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         # The presence of a missing/NaN in either bounding interval poisons the prominence
         m4 = [missing; p4; missing]
         n4 = [NaN; p4; NaN]
-        @test prod(last(peakprom(m4)) .=== [missing,1,missing])
-        @test prod(last(peakprom(n4)) .=== [NaN,1.,NaN])
+        @test isequal(last(peakprom(m4)), [missing,1,missing])
+        @test isequal(last(peakprom(n4)), [NaN,1.,NaN])
         @test last(peakprom(m4; strictbounds=false)) == [2,1,1]
-        @test last(peakprom(n4; strictbounds=false)) ≈ [2.,1.,1.] atol=0.01
+        @test last(peakprom(n4; strictbounds=false)) == [2.,1.,1.]
 
         @test_skip peakprom([missing,1,missing]; strictbounds=false) == [missing]
 

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -62,7 +62,7 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
     @testset "Minimum prominence" begin
         minprom = 1.5
         i, p = peakprom(sin.(1e-5:1e-5:9*pi))
-        mi, mp = peakprom(sin.(1e-5:1e-5:9*pi); minprom)
+        mi, mp = peakprom(sin.(1e-5:1e-5:9*pi); minprom=minprom)
         @test all(x -> x >= minprom, mp)
     end
 


### PR DESCRIPTION
Ref [comment from #9](https://github.com/halleysfifthinc/Peaks.jl/issues/9#issuecomment-638329428
)

There are three types of analogous extremum functions in base: min-/maximum (returns value), argmin/max (returns index), and findmin/max (returns tuple(value, index)).

This PR renames the old min-/maxima => argmin-/argmaxima, adds new functions find(minima/maxima) the return a tuple (index, value) (this is the reverse of the `findmin` index/val order, but, more reasonably imo, matches the `enumerate` order).

The old `maxima`/`minima` functions are deprecated and will be brought back in the future to return the values instead of indices.