### PR TITLE
Fix plot tests writing files in read-only directories

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Peaks"
 uuid = "18e31ff7-3703-566c-8e60-38913d67486b"
 authors = ["Allen Hill <allenofthehills@gmail.com>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -11,19 +11,14 @@ let
         plt = plotpeaks(t, y, peaks=pks, prominences=true, widths=true)
         @test plt isa Plots.Plot
 
-        savepath_png = abspath(joinpath(@__DIR__, "..", "docs", "src", "assets", "images", "maxima_prom_width.png"))
-        savefig(plt, savepath_png)
-
         # add minima to plot
         pks, vals = findminima(y)
         pks, proms = peakproms!(pks, y; minprom=1)
         plt = plotpeaks!(t, y, peaks=pks, prominences=true, widths=true)
         @test plt isa Plots.Plot
-        savepath_png = abspath(joinpath(@__DIR__, "..", "docs", "src", "assets", "images", "extrema_prom_width.png"))
-        savefig(plt, savepath_png)
 
-        plt = plotpeaks(t, y, peaks=pks, prominences=true, widths=true)
-        savepath_png = abspath(joinpath(@__DIR__, "..", "docs", "src", "assets", "images", "minima_prom_width.png"))
-        savefig(plt, savepath_png)
+        # plt = plotpeaks(t, y, peaks=pks, prominences=true, widths=true)
+        # savepath_png = abspath(joinpath(@__DIR__, "..", "docs", "src", "assets", "images", "minima_prom_width.png"))
+        # savefig(plt, savepath_png)
     end
 end


### PR DESCRIPTION
Problematic lines ran `savefig` to update the saved plots in `assets`, but testing is not the right time/place to do that.