### PR TITLE
Union branches in peakproms! in assigning to proms

### DIFF
--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -203,7 +203,17 @@ function peakproms!(peaks::AbstractVector{Int}, x::AbstractVector{T};
                 rref = exm(view(notmval, k:rb)) # Slice corollary upper side
             end
 
-            proms[i] = abs(x[peaks[i]] - exa(coalesce(lref, rref), coalesce(rref, lref)))
+            proms[i] =  abs(x[peaks[i]] -
+                            # exa(coalesce(lref, rref), coalesce(rref, lref)))
+                            # we manually union-split this for better type-inference
+                            if ismissing(lref)
+                                rref
+                            elseif ismissing(rref)
+                                lref
+                            else
+                                exa(lref, rref)
+                            end
+                        )
         end
     end
 


### PR DESCRIPTION
This reduces the number of branches that inference needs to traverse, which makes it likely to infer the return type concretely.

On master,
```julia
julia> f(x) = exp(-(x-3)^2/(2*0.3^2)) + exp(-(x-5)^2/(2*0.3^2)) + exp(-(x-7)^2/(2*0.4^2))
f (generic function with 1 method)

julia> v = f.(1:0.1:10);

julia> inds = argmaxima(v)
3-element Vector{Int64}:
 21
 41
 61

julia> @btime peakproms($inds, $v, strict=false);
  3.654 μs (33 allocations: 1.11 KiB)
```
This PR
```julia
julia> @btime peakproms!(i, $v, strict=false) setup=(i=$inds);
  3.211 μs (15 allocations: 848 bytes)
```