### PR TITLE
Reduce allocations in various functions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - main
+      - 'release*'
+  pull_request:
 
 # needed to allow julia-actions/cache to delete old caches that it has created
 permissions:

--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -93,15 +93,7 @@ function _strict_inner_promscalcloop!(cmp::C, extremum::M, extrema::A, _ref::MT,
                 rref = extremum(view(x, (peaks[i]+1):rb))
             end
 
-            exa_ref = if ismissing(lref)
-                rref
-            elseif ismissing(rref)
-                lref
-            else
-                extrema(lref, rref)
-            end
-
-            proms[i] = abs(x[peaks[i]] - exa_ref)
+            proms[i] = abs(x[peaks[i]] - extrema(lref, rref))
         end
 
         return nothing

--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -253,12 +253,11 @@ function peakproms!(peaks::AbstractVector{Int}, x::AbstractVector{T};
     return peaks, proms
 end
 
-function peakproms!(pks::NamedTuple; strict=true, min=nothing, max=nothing)
+function peakproms!(pks::NamedTuple{names,Ts}; strict=true, min=nothing, max=nothing) where {names,Ts}
     if !hasproperty(pks, :proms)
-        # Avoid filtering by min/max/strict here, so that it always happens outside if-statement.
-        # Pro: one less edge case. Con: More internal allocations
+        # Wait to filter until after merging `pks`
         _, proms = peakproms(pks.indices, pks.data; strict)
-        pks = merge(pks, (; proms))
+        pks = NamedTuple{(names..., :proms)}((values(pks)..., proms))
     end
     filterpeaks!(pks, :proms; min, max)
     return pks

--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -190,13 +190,11 @@ function peakproms!(peaks::AbstractVector{Int}, x::AbstractVector{T};
 
             # Find left and right bounding peaks
             if maxima # cmp = ≥, manual union-splitting
-                _lb = findprev(y -> ≥(x[y], x[peaks[i]]) === true, peaks′, first(j) - 1)
-                peaks′[j] === peaks[i] && (j += 1)
-                _rb = findnext(y -> ≥(x[y], x[peaks[i]]) === true, peaks′, last(j) + 1)
+                _lb = findprev(y -> ≥(x[y], x[peaks[i]]) === true, peaks′, j - 1)
+                _rb = findnext(y -> ≥(x[y], x[peaks[i]]) === true, peaks′, j + 1)
             else # cmp = ≤
-                _lb = findprev(y -> ≤(x[y], x[peaks[i]]) === true, peaks′, first(j) - 1)
-                peaks′[j] === peaks[i] && (j += 1)
-                _rb = findnext(y -> ≤(x[y], x[peaks[i]]) === true, peaks′, last(j) + 1)
+                _lb = findprev(y -> ≤(x[y], x[peaks[i]]) === true, peaks′, j - 1)
+                _rb = findnext(y -> ≤(x[y], x[peaks[i]]) === true, peaks′, j + 1)
             end
 
             # Find left and right reverse peaks just inside the bounding peaks

--- a/src/peakprom.jl
+++ b/src/peakprom.jl
@@ -186,7 +186,7 @@ function peakproms!(peaks::AbstractVector{Int}, x::AbstractVector{T};
         notmval = x[notm]
 
         for i in eachindex(peaks, proms)
-            j = searchsorted(peaks′, peaks[i])
+            j = only(searchsorted(peaks′, peaks[i]))
 
             # Find left and right bounding peaks
             if maxima # cmp = ≥, manual union-splitting

--- a/src/peakwidth.jl
+++ b/src/peakwidth.jl
@@ -79,7 +79,7 @@ peakwidths(; kwargs...) = function _curried_peakwidths(pks)
     return peakwidths(pks; kwargs...)
 end
 
-function _inner_widthscalcloop!(op::O, cmp::C, x::AbstractVector{T}, peaks::AbstractVector{Int}, proms::AbstractVector{Union{Missing,T}}, ledge::AbstractVector{V}, redge::AbstractVector{V}, relheight::U, _bad, fst, lst, strict::Bool) where {O,C,T,V,U}
+function _inner_widthscalcloop!(op::O, cmp::C, x::AbstractVector{T}, peaks::AbstractVector{Int}, proms::AbstractVector{P}, ledge::AbstractVector{V}, redge::AbstractVector{V}, relheight::U, _bad, fst, lst, strict::Bool) where {O,C,T,P,V,U}
     for i in eachindex(peaks, ledge, redge)
         prom = proms[i]
         if ismissing(prom) || isnan(prom)

--- a/src/peakwidth.jl
+++ b/src/peakwidth.jl
@@ -79,6 +79,40 @@ peakwidths(; kwargs...) = function _curried_peakwidths(pks)
     return peakwidths(pks; kwargs...)
 end
 
+function _inner_widthscalcloop!(op::O, cmp::C, x::AbstractVector{T}, peaks::AbstractVector{Int}, proms::AbstractVector{Union{Missing,T}}, ledge::AbstractVector{V}, redge::AbstractVector{V}, relheight::U, _bad, fst, lst, strict::Bool) where {O,C,T,V,U}
+    for i in eachindex(peaks, ledge, redge)
+        prom = proms[i]
+        if ismissing(prom) || isnan(prom)
+            redge[i] = _bad
+            ledge[i] = _bad
+        else
+            ht = op(x[peaks[i]], relheight * prom)
+            lo = findprev(v -> !ismissing(v) && cmp(v, ht), x, peaks[i])
+            hi = findnext(v -> !ismissing(v) && cmp(v, ht), x, peaks[i])
+
+            if !strict
+                if !isnothing(lo)
+                    lo1 = findnext(v -> !ismissing(v) && cmp(ht, v), x, lo + 1)
+                    @assert !isnothing(lo1)
+                    lo += (ht - x[lo]) / (x[lo1] - x[lo]) * (lo1 - lo)
+                end
+                if !isnothing(hi)
+                    hi1 = findprev(v -> !ismissing(v) && cmp(ht, v), x, hi - 1)
+                    @assert !isnothing(hi1)
+                    hi -= (ht - x[hi]) / (x[hi1] - x[hi]) * (hi - hi1)
+                end
+            else
+                !isnothing(lo) && (lo += (ht - x[lo]) / (x[lo+1] - x[lo]))
+                !isnothing(hi) && (hi -= (ht - x[hi]) / (x[hi-1] - x[hi]))
+            end
+            redge[i] = something(hi, lst)
+            ledge[i] = something(lo, fst)
+        end
+    end
+
+    return nothing
+end
+
 """
     peakwidths!(indices, x; [strict=true, relheight=0.5, min, max]) -> (indices, widths, ledge, redge)
     peakwidths!(pks::NamedTuple; [strict=true, relheight=0.5, min, max]) -> NamedTuple
@@ -132,8 +166,6 @@ function peakwidths!(
     else
         throw(ArgumentError("The first peak in `indices` is not a local extrema"))
     end
-    cmp = maxima ? (≤) : (≥)
-    op = maxima ? (-) : (+)
 
     V1 = promote_type(T, U)
     _bad = Missing <: V1 ? missing : float(Int)(NaN)
@@ -141,6 +173,7 @@ function peakwidths!(
     V = promote_type(V1, float(Int))
     ledge = similar(proms, V)
     redge = similar(proms, V)
+    widths = similar(proms, V)
 
     if strict
         lst, fst = _bad, _bad
@@ -149,35 +182,13 @@ function peakwidths!(
         fst = firstindex(x)
     end
 
-    for i in eachindex(peaks, ledge, redge)
-        prom = proms[i]
-        if ismissing(prom) || isnan(prom)
-            redge[i] = _bad
-            ledge[i] = _bad
-        else
-            ht = op(x[peaks[i]], relheight * proms[i])
-            lo = findprev(v -> !ismissing(v) && cmp(v, ht), x, peaks[i])
-            hi = findnext(v -> !ismissing(v) && cmp(v, ht), x, peaks[i])
-
-            if !strict
-                if !isnothing(lo)
-                    lo1 = findnext(v -> !ismissing(v) && cmp(ht, v), x, lo + 1)
-                    lo += (ht - x[lo]) / (x[lo1] - x[lo]) * (lo1 - lo)
-                end
-                if !isnothing(hi)
-                    hi1 = findprev(v -> !ismissing(v) && cmp(ht, v), x, hi - 1)
-                    hi -= (ht - x[hi]) / (x[hi1] - x[hi]) * (hi - hi1)
-                end
-            else
-                !isnothing(lo) && (lo += (ht - x[lo]) / (x[lo+1] - x[lo]))
-                !isnothing(hi) && (hi -= (ht - x[hi]) / (x[hi-1] - x[hi]))
-            end
-            redge[i] = something(hi, lst)
-            ledge[i] = something(lo, fst)
-        end
+    if maxima
+        _inner_widthscalcloop!(-, ≤, x, peaks, proms, ledge, redge, relheight, _bad, fst, lst, strict)
+    else
+        _inner_widthscalcloop!(+, ≥, x, peaks, proms, ledge, redge, relheight, _bad, fst, lst, strict)
     end
 
-    widths::Vector{V} = redge - ledge
+    widths .= redge .- ledge
 
     if !isnothing(min) || !isnothing(max)
         lo = something(min, zero(eltype(widths)))

--- a/src/peakwidth.jl
+++ b/src/peakwidth.jl
@@ -204,14 +204,13 @@ function peakwidths!(
 end
 
 function peakwidths!(pks::NamedTuple; strict=true, relheight=0.5, min=nothing, max=nothing)
-    !haskey(pks, :proms) && throw(ArgumentError(
+    !hasproperty(pks, :proms) && throw(ArgumentError(
         "Argument `pks` is expected to have prominences (`:proms`) already calculated"))
     if xor(hasproperty(pks, :widths), hasproperty(pks, :edges))
         throw(ArgumentError("Argument `pks` is expected have neither or both of the fields `:widths` and `:edges`."))
     end
     if !hasproperty(pks, :widths)
-        # Avoid filtering by min/max/strict here, so that it always happens outside if-statement.
-        # Pro: one less edge case. Con: More internal allocations
+        # Wait to filter until after merging `pks`
         _, widths, leftedges, rightedges = peakwidths(pks.indices, pks.data, pks.proms; relheight, strict)
         pks = merge(pks, (; widths, edges=collect(zip(leftedges, rightedges))))
     end

--- a/test/peakprom.jl
+++ b/test/peakprom.jl
@@ -47,6 +47,11 @@ x1 = a*sin.(2*pi*f1*T*t)+b*sin.(2*pi*f2*T*t)+c*sin.(2*pi*f3*T*t);
         @test last(peakproms(argmaxima(p4[2:end-1]), p4[2:end-1])) == [1]
         @test last(peakproms(argmaxima(p4[2:end-1]; strict=false), p4[2:end-1]; strict=false)) == [2,1,1]
 
+        # Plateaus have the same prominence
+        p4_plat = [0,4,2,4,4,3,4,0]
+        @test last(peakproms(argmaxima(p4_plat), p4_plat)) == [2,1,1]
+        @test last(peakproms(argmaxima(p4_plat), p4_plat; strict=false)) == [2,1,1]
+
         # The presence of a missing/NaN in either bounding interval poisons the prominence
         m4 = [missing; p4; missing]
         n4 = [NaN; p4; NaN]


### PR DESCRIPTION
The problem areas in these functions were found with a combination of `@report_opt` from JET.jl and `@profview_allocs` from ProfileCanvas.jl.

Benchmarks:
```julia
@benchmark peakproms!(pks) setup=(pks = findmaxima([0,5,2,3,3,1,4,0]))
# master 2.8 μs; 18 allocs, 848 bytes
# PR min 337 ns; 4 allocs, 224 bytes

@benchmark peakproms!(pks; strict=false) setup=(pks = findmaxima([0,5,2,3,3,1,4,0]))
# master 2.98 μs; 26 allocs, 1.25 KiB
# PR min 625 ns; 9 allocs, 608 bytes

@benchmark peakwidths!(pks) setup=(pks = peakproms(findmaxima([0,5,2,3,3,1,4,0])))
# master 2.2 μs; 51 allocs, 1.25 KiB
# PR min 418 ns; 14 allocs, 624 bytes

@benchmark peakwidths!(pks; strict=false) setup=(pks = peakproms(findmaxima([0,5,2,3,3,1,4,0])))
# master 2.95 μs; 69 allocs, 1.53 KiB
# PR min 434 ns; 14 allocs, 624 bytes

@benchmark filterpeaks!(pks, :heights; min=1) setup=(pks = findmaxima([0,5,2,3,3,1,4,0]))
# master 264 ns; 8 allocs, 464 bytes
# PR min 64 ns; 1 allocs, 64 bytes
```
